### PR TITLE
Adds CU Boulder Styled Block custom module and updates block styles (v1.1)

### DIFF
--- a/ucb_campus_news.info.yml
+++ b/ucb_campus_news.info.yml
@@ -6,3 +6,4 @@ version: '1.1'
 package: CU Boulder
 dependencies:
   - block
+  - ucb_styled_block

--- a/ucb_campus_news.info.yml
+++ b/ucb_campus_news.info.yml
@@ -2,7 +2,7 @@ name: CU Boulder Campus News
 description: 'Provides a block for CU Boulder campus news.'
 core_version_requirement: '^9.5 || ^10'
 type: module
-version: '1.0.1'
+version: '1.1'
 package: CU Boulder
 dependencies:
   - block


### PR DESCRIPTION
This update:
- [new] Adds the new CU Boulder Styled Block custom module.
- [new] Converts the Campus News block to a styled block, adding new style options to match our other blocks. Resolves CuBoulder/ucb_campus_news#6 Resolves CuBoulder/ucb_campus_news#9
- [change] Refactors existing styled blocks to all extend the same Twig template with Twig inheritance.
- [change] Corrects some indentation and other minor code style issues in affected block templates.

Sister PR in: [tiamat-theme](https://github.com/CuBoulder/tiamat-theme/pull/1209), [tiamat10-profile](https://github.com/CuBoulder/tiamat10-profile/pull/187), [tiamat10-project-template](https://github.com/CuBoulder/tiamat10-project-template/pull/55)