### PR TITLE
Adds support for the Drupal 10 version of CU Boulder Today (v2.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
-# CU Boulder Default Content
+# CU Boulder Campus News
 
 All notable changes to this project will be documented in this file.
 
-Repo : [GitHub Repository](https://github.com/CuBoulder/ucb_default_content)
+Repo : [GitHub Repository](https://github.com/CuBoulder/ucb_campus_news)
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/README.md
+++ b/README.md
@@ -1,0 +1,30 @@
+# CU Boulder Campus News
+
+This Drupal module contains the Campus News block, which pulls news articles
+from [CU Boulder Today](https://www.colorado.edu/today) using the JSON API.
+
+## Dependencies
+
+- [CU Boulder Styled Block](https://github.com/CuBoulder/ucb_styled_block)
+  - Needed on every site with CU Boulder Campus News installed.
+- [CU Boulder Article Syndication](https://github.com/CuBoulder/ucb_article_syndication)
+  - Needed on the Today site only.
+
+## Major Releases
+
+- Fall 2022: Initial support for the Drupal 7 (legacy) Today site (v1.0).
+- Fall 2024: Initial support for the modern Today site JSON API (v2.0).
+
+## Why is a custom module needed for this block specifically?
+
+The Campus News block editing form automatically pulls existing taxonomy terms
+for category, audience, and unit from the CU Boulder Today site to enable
+filtering (audience and unit are added by the
+[CU Boulder Article Syndication](https://github.com/CuBoulder/ucb_article_syndication)
+module installed on the Today site). Due to the way Drupal handles block types,
+we determined this wasn't feasable with a standard block type.
+
+The Campus News block is a programatic block written in PHP & JavaScript with
+some JavaScript trickery to make the asynchronous fetching of terms possible.
+When the editor saves these filters, the term ids are stored and used in
+subsequent API requests to provide the correct news articles to viewers.

--- a/config/install/ucb_campus_news.configuration.yml
+++ b/config/install/ucb_campus_news.configuration.yml
@@ -1,13 +1,13 @@
 filters:
   categories:
-    label: 'Category'
-    taxonomy: 'category'
+    label: Category
+    taxonomy: category
   audiences:
-    label: 'Audience'
-    taxonomy: 'syndication_audience'
+    label: Audience
+    taxonomy: syndication_audience
   units:
-    label: 'Unit'
-    taxonomy: 'syndication_unit'
+    label: Unit
+    taxonomy: syndication_unit
 filterIncludeLimit: 128
 display:
   label: Display

--- a/config/install/ucb_campus_news.configuration.yml
+++ b/config/install/ucb_campus_news.configuration.yml
@@ -1,3 +1,4 @@
+baseURL: 'https://www.colorado.edu/today'
 filters:
   categories:
     label: Category

--- a/config/install/ucb_campus_news.configuration.yml
+++ b/config/install/ucb_campus_news.configuration.yml
@@ -1,16 +1,13 @@
-siteURI: 'https://www.colorado.edu/today/syndicate/article/read'
-baseURI: 'https://www.colorado.edu/today/syndicate/article'
-path: '/'
 filters:
   categories:
     label: 'Category'
-    path: '/options/category'
+    taxonomy: 'category'
   audiences:
     label: 'Audience'
-    path: '/options/syndication_audience'
+    taxonomy: 'syndication_audience'
   units:
     label: 'Unit'
-    path: '/options/syndication_unit'
+    taxonomy: 'syndication_unit'
 filterIncludeLimit: 128
 display:
   label: Display

--- a/css/ucb-campus-news.css
+++ b/css/ucb-campus-news.css
@@ -1,9 +1,9 @@
-.ucb-campus-news-link-container {
+campus-news .ucb-campus-news-link-container {
   clear: both;
   text-align: right;
 }
 
-.ucb-campus-news-grid-link {
+campus-news .ucb-campus-news-grid-link {
   display: inline-block;
   padding: 5px 10px;
   font-weight: bold;
@@ -20,53 +20,53 @@
   border: 1px solid currentColor;
 }
 
-.ucb-campus-news-title-only {
+campus-news .ucb-campus-news-title-only {
   display: block;
   padding: 5px 0;
 }
 
-.campus-news-article-grid{
+campus-news .campus-news-article-grid {
   margin-bottom: 20px;
 }
 
-.campus-news-article-grid > a {
+campus-news .campus-news-article-grid > a {
   font-weight: bolder;
   margin-top: 5px;
   margin-bottom: 5px;
 }
 
-.campus-news-article-teaser {
+campus-news .campus-news-article-teaser {
   margin-bottom: 20px;
   border-bottom: 1px solid rgba(128, 128, 128, 0.333);
   padding-bottom: 20px;
 }
 
-.ucb-campus-news-title-thumbnail-only {
+campus-news .ucb-campus-news-title-thumbnail-only {
   margin-bottom: 10px;
   border-bottom: 1px solid rgba(128, 128, 128, 0.333);
   padding-bottom: 10px;
 }
 
-.ucb-campus-news-grid-link-container {
+campus-news .ucb-campus-news-grid-link-container {
   text-align: center;
 }
 
-.campus-news-article-teaser > .field-name-field-article-thumbnail {
+campus-news .campus-news-article-teaser > .field-name-field-article-thumbnail {
   min-width: 100px;
   min-height: 100px;
   max-width: 100px;
   max-height: 100px;
 }
 
-.campus-news-article-teaser > .field-name-field-article-thumbnail {
+campus-news .campus-news-article-teaser > .field-name-field-article-thumbnail {
   margin-right: 20px;
 }
 
-.campus-news-article-teaser > div > a {
+campus-news .campus-news-article-teaser > div > a {
   font-weight: bolder;
 }
 
-.ucb-campus-news-title-thumbnail-only > .field-name-field-article-thumbnail{
+campus-news .ucb-campus-news-title-thumbnail-only > .field-name-field-article-thumbnail {
   min-width: 75px;
   min-height: 75px;
   max-width: 75px;
@@ -74,31 +74,36 @@
   margin-right: 10px;
 }
 
-.article-feature-block-remaining > .ucb-campus-news-title-thumbnail-only > .field-name-field-article-thumbnail > a > .image-slider {
+campus-news .article-feature-block-remaining > .ucb-campus-news-title-thumbnail-only > .field-name-field-article-thumbnail > a > .image-slider {
   max-width: 100%;
   height: 80px;
   object-fit: cover;
 }
 
-.campus-news-article-feature > .field-name-field-article-thumbnail {
+campus-news .campus-news-article-feature > .field-name-field-article-thumbnail {
   margin-bottom: 10px;
 }
 
-.campus-news-article-feature > a:nth-child(2) {
+campus-news .campus-news-article-feature > a:nth-child(2) {
   font-weight: bold;
   font-size: 130%;
   line-height: 1.3;
 }
 
-.campus-news-article-feature > .field-name-body {
-  margin-top: 10px;
-}
-
-.ucb-campus-news-date {
+campus-news .campus-news-article-date {
   margin-bottom: 0;
   font-size: 85%;
 }
 
-.ucb-campus-news-error-container {
+campus-news .campus-news-article-summary {
+  margin: 0;
+}
+
+campus-news .campus-news-article-feature > .field-name-body,
+campus-news .campus-news-article-feature > .campus-news-article-summary {
+  margin-top: 10px;
+}
+
+campus-news .ucb-campus-news-error-container {
   text-align: center;
 }

--- a/css/ucb-campus-news.css
+++ b/css/ucb-campus-news.css
@@ -51,14 +51,16 @@ campus-news .ucb-campus-news-grid-link-container {
   text-align: center;
 }
 
-campus-news .campus-news-article-teaser > .field-name-field-article-thumbnail {
+campus-news .campus-news-article-teaser > .field-name-field-article-thumbnail,
+campus-news .campus-news-article-teaser > .campus-news-article-thumbnail {
   min-width: 100px;
   min-height: 100px;
   max-width: 100px;
   max-height: 100px;
 }
 
-campus-news .campus-news-article-teaser > .field-name-field-article-thumbnail {
+campus-news .campus-news-article-teaser > .field-name-field-article-thumbnail,
+campus-news .campus-news-article-teaser > .campus-news-article-thumbnail {
   margin-right: 20px;
 }
 
@@ -66,7 +68,12 @@ campus-news .campus-news-article-teaser > div > a {
   font-weight: bolder;
 }
 
-campus-news .ucb-campus-news-title-thumbnail-only > .field-name-field-article-thumbnail {
+campus-news
+  .ucb-campus-news-title-thumbnail-only
+  > .field-name-field-article-thumbnail,
+campus-news
+  .ucb-campus-news-title-thumbnail-only
+  > .campus-news-article-thumbnail {
   min-width: 75px;
   min-height: 75px;
   max-width: 75px;
@@ -74,13 +81,25 @@ campus-news .ucb-campus-news-title-thumbnail-only > .field-name-field-article-th
   margin-right: 10px;
 }
 
-campus-news .article-feature-block-remaining > .ucb-campus-news-title-thumbnail-only > .field-name-field-article-thumbnail > a > .image-slider {
+campus-news
+  .article-feature-block-remaining
+  > .ucb-campus-news-title-thumbnail-only
+  > .field-name-field-article-thumbnail
+  > a
+  > .image-slider,
+campus-news
+  .article-feature-block-remaining
+  > .ucb-campus-news-title-thumbnail-only
+  > .field-name-field-article-thumbnail
+  > a
+  > .campus-news-article-thumbnail-image {
   max-width: 100%;
   height: 80px;
   object-fit: cover;
 }
 
-campus-news .campus-news-article-feature > .field-name-field-article-thumbnail {
+campus-news .campus-news-article-feature > .field-name-field-article-thumbnail,
+campus-news .campus-news-article-feature > .campus-news-article-thumbnail {
   margin-bottom: 10px;
 }
 

--- a/js/cuboulder-today-filter-form-loader.js
+++ b/js/cuboulder-today-filter-form-loader.js
@@ -133,7 +133,7 @@ function cuboulderTodayFilterFormLoader(drupal, baseURL, label, taxonomy, machin
     if (isSelected) {
       // Can't be indeterminate if selected.
       isIndeterminate = false;
-    } else if (!isSelected && !isIndeterminate && included) {
+    } else if (!isIndeterminate && included) {
       // The parent term is in the filter includes and none of the children
       // are. This is a state common from versions of Campus News before 2.0.
       isIndeterminate = true;

--- a/js/cuboulder-today-filter-form-loader.js
+++ b/js/cuboulder-today-filter-form-loader.js
@@ -11,6 +11,7 @@
  *   sorted: boolean;
  *   formElement: HTMLElement | null;
  * }} TaxonomyTreeNode
+ *
  * @typedef {{ enabled: number; includes: []; }} FilterConfiguration
  */
 

--- a/js/cuboulder-today-filter-form-loader.js
+++ b/js/cuboulder-today-filter-form-loader.js
@@ -293,7 +293,6 @@ function cuboulderTodayFilterFormLoader(drupal, baseURL, label, taxonomy, machin
    *   The root node of the taxonomy tree.
    */
   async function jsonAPILoadTree() {
-    // TODO: Change to production URL.
     const data = await jsonAPIFetchData(baseURL + '/jsonapi/taxonomy_term/' + taxonomy);
 
     const root = createRootNode(), tidMap = new Map();

--- a/js/cuboulder-today-filter-form-loader.js
+++ b/js/cuboulder-today-filter-form-loader.js
@@ -130,7 +130,10 @@ function cuboulderTodayFilterFormLoader(drupal, baseURL, label, taxonomy, machin
       isIndeterminate = isIndeterminate || childStatus[0] || childStatus[1];
     });
 
-    if (!isSelected && !isIndeterminate && included) {
+    if (isSelected) {
+      // Can't be indeterminate if selected.
+      isIndeterminate = false;
+    } else if (!isSelected && !isIndeterminate && included) {
       // The parent term is in the filter includes and none of the children
       // are. This is a state common from versions of Campus News before 2.0.
       isIndeterminate = true;

--- a/js/cuboulder-today-filter-form-loader.js
+++ b/js/cuboulder-today-filter-form-loader.js
@@ -1,4 +1,8 @@
-function cuboulderTodayFilterFormLoader(drupal, siteURI, baseURI, label, path, machineName, configuration) {
+/**
+ * @typedef {{ id: number, name: string, parents: TaxonomyTreeNode[], children: TaxonomyTreeNode[], weight: number, sorted: boolean, formElement: HTMLElement | null }} TaxonomyTreeNode
+ */
+
+function cuboulderTodayFilterFormLoader(drupal, label, taxonomy, machineName, configuration) {
   const
     containerElement = document.getElementById('cuboulder_today_filter_form_container_' + machineName),
     checkboxesElement = containerElement.getElementsByTagName('div')[0],
@@ -6,11 +10,193 @@ function cuboulderTodayFilterFormLoader(drupal, siteURI, baseURI, label, path, m
     checkboxElementHTML = checkboxesElement.innerHTML,
     showAllElement = document.getElementById('cuboulder_today_filter_form_enable_' + machineName);
   let loadRequested = false, loadComplete = false;
-  function _buildTree(data) {
-    const root = {id: 0, parents: [], children: [], sorted: false, formElement: null}, tidMap = new Map();
+
+  /**
+   * Creates a new root node for the tree.
+   *
+   * @returns {TaxonomyTreeNode}
+   *   The node.
+   */
+  function createRootNode() {
+    return { id: 0, name: 'ROOT', parents: [], children: [], weight: 0, sorted: false, formElement: null };
+  }
+
+  /**
+   * Sorts each level of the taxonomy tree by the weight of each node.
+   *
+   * @param {TaxonomyTreeNode} node
+   *   The root node of the tree.
+   * @returns
+   *   The root node of the tree with child nodes sorted.
+   */
+  function sortTree(node) {
+    if(!node.sorted) {
+      node.sorted = true;
+      if(node.children) {
+        node.children.sort((nodeA, nodeB) => nodeA.weight - nodeB.weight).forEach(node => sortTree(node));
+      }
+    }
+    return node;
+  }
+
+  /**
+   * Displays the taxonomy tree as checkboxes in the form.
+   *
+   * Trees are displayed as multi-level with child items below parent items. If
+   * a parent checkbox is selected, all children must be as well.
+   *
+   * @param {TaxonomyTreeNode} node
+   *   The node of the tree at the current level.
+   * @param {HTMLElement} parentElement
+   *   The HTML element to place the checkbox into.
+   * @param {boolean} parentSelected
+   *   Whether or not the parent checkbox is selected (if applicable).
+   * @param {string} trail
+   *   The trail followed.
+   */
+  function displayTree(node, parentElement, parentSelected, trail) { 
+    trail += '-' + node.id;
+    const
+      container = node.formElement = document.createElement('div'),
+      checkboxHTML = checkboxElementHTML.replace(/cuboulder_today_filter_loading|cuboulder-today-filter-loading/g, trail),
+      includes = configuration.includes,
+      isSelected = includes.indexOf(node.id) != -1;
+    container.className = 'cuboulder-today-filter-form-options ' + checkboxesElement.className;
+    container.innerHTML = checkboxHTML;
+    const checkbox = container.querySelector('input[type="checkbox"]'), label = container.querySelector('label');
+    label.innerText = node.name;
+    if(isSelected || parentSelected) {
+      checkbox.setAttribute('checked', 'checked');
+    }
+    checkbox.addEventListener('change', function(event) {
+      if(event.currentTarget.checked) {
+        checkAllChildren(node);
+      } else {
+        uncheckAllParents(node);
+        uncheckAllChildren(node);
+      }
+    });
+    node.children.forEach(node => displayTree(node, container, parentSelected || isSelected, trail));
+    parentElement.appendChild(container);
+  }
+
+  /**
+   * Given a node, checks the associated checkbox.
+   *
+   * @param {TaxonomyTreeNode} node
+   *   The node.
+   */
+  function checkNode(node) {
+    const formElement = node.formElement;
+    if(formElement) {
+      node.formElement.querySelector('input[type="checkbox"]').checked = true;
+    }
+  }
+
+  /**
+   * Given a node, unchecks the associated checkbox.
+   *
+   * @param {TaxonomyTreeNode} node
+   *   The node.
+   */
+  function uncheckNode(node) {
+    const formElement = node.formElement;
+    if(formElement) {
+      node.formElement.querySelector('input[type="checkbox"]').checked = false;
+    }
+  }
+
+  /**
+   * Given a node, unchecks the associated checkboxs of all its parent nodes.
+   *
+   * @param {TaxonomyTreeNode} node
+   *   The node.
+   */
+  function uncheckAllParents(node) {
+    node.parents.forEach(parentNode => {
+      uncheckNode(parentNode);
+      uncheckAllParents(parentNode);
+    });
+  }
+
+  /**
+   * Given a node, checks the associated checkboxs of all its child nodes.
+   *
+   * @param {TaxonomyTreeNode} node
+   *   The node.
+   */
+  function checkAllChildren(node) {
+    node.children.forEach(childNode => {
+      checkNode(childNode);
+      checkAllChildren(childNode);
+    });
+  }
+
+  /**
+   * Given a node, unchecks the associated checkboxs of all its child nodes.
+   *
+   * @param {TaxonomyTreeNode} node
+   *   The node.
+   */
+  function uncheckAllChildren(node) {
+    node.children.forEach(childNode => {
+      uncheckNode(childNode);
+      uncheckAllChildren(childNode);
+    });
+  }
+
+  /**
+   * Loads and displays a taxonomy filter form.
+   */
+  async function load() {
+    loadRequested = true;
+    const loaderDiv = document.createElement('div');
+    loaderDiv.innerHTML = drupal.theme.ajaxProgressThrobber();
+    containerElement.insertBefore(loaderDiv, containerElement.childNodes[0]);
+    checkboxesElement.innerHTML = '';
+
+    let tree;
+    try {
+      tree = await jsonAPILoadTree();
+    } catch (exception) {
+      tree = await legacyLoadTree();
+    }
+
+    tree.children.forEach(node => displayTree(node, checkboxesElement, false, '0'));
+    containerElement.removeChild(loaderDiv);
+    loadComplete = true;
+  }
+
+  /**
+   * Fetches a taxonomy tree using the Today site JSON API.
+   *
+   * @return {TaxonomyTreeNode}
+   *   The root node of the taxonomy tree.
+   */
+  async function jsonAPILoadTree() {
+    const response = await fetch('https://live-ucbprod-today.pantheonsite.io/jsonapi/taxonomy_term/' + taxonomy);
+    const data = await response.json();
+
+    // TODO: Implement the API handling logic here.
+
+    throw new Error('Not yet implemented.');
+  }
+
+  /**
+   * Fetches a taxonomy tree using the legacy (Drupal 7) Today site API.
+   *
+   * @return {TaxonomyTreeNode}
+   *   The root node of the taxonomy tree.
+   */
+  async function legacyLoadTree() {
+    const response = await fetch('https://www.colorado.edu/today/syndicate/article/options/' + taxonomy);
+    const data = await response.json();
+
+    const root = createRootNode(), tidMap = new Map();
     tidMap.set(0, root);
     data.sort((itemA, itemB) => itemA['depth'] - itemB['depth']).forEach((item) => {
-      const id = parseInt(item['tid']), node = {
+      const id = parseInt(item['tid']);
+      const node = {
         id: id,
         uuid: item['uuid'],
         name: item['name'],
@@ -30,90 +216,18 @@ function cuboulderTodayFilterFormLoader(drupal, siteURI, baseURI, label, path, m
         }
       });
     });
-    return root;
+
+    return sortTree(root);
   }
-  function _sortTree(node) {
-    if(!node.sorted) {
-      node.sorted = true;
-      if(node.children)
-        node.children.sort((nodeA, nodeB) => nodeA.weight - nodeB.weight).forEach((node) => _sortTree(node));
-    }
-    return node;
-  }
-  function _displayTree(node, parentElement, parentSelected, trail) { 
-    trail += '-' + node.id;
-    const
-      container = node.formElement = document.createElement('div'),
-      checkboxHTML = checkboxElementHTML.replace(/cuboulder_today_filter_loading|cuboulder-today-filter-loading/g, trail),
-      includes = configuration['includes'],
-      isSelected = includes.indexOf(node.id) != -1;
-    container.className = 'cuboulder-today-filter-form-options ' + checkboxesElement.className;
-    container.innerHTML = checkboxHTML;
-    const checkbox = container.querySelector('input[type="checkbox"]'), label = container.querySelector('label');
-    label.innerText = node.name;
-    if(isSelected || parentSelected)
-      checkbox.setAttribute('checked', 'checked');
-    checkbox.addEventListener('change', function(event) {
-      if(event.currentTarget.checked) {
-        _checkAllChildren(node);
-      } else {
-        _uncheckAllParents(node);
-        _uncheckAllChildren(node);
+
+  if(configuration.enabled || showAllElement.checked) {
+    load();
+  } else {
+    showAllElement.addEventListener('change', event => {
+      if(!loadRequested && event.currentTarget.checked) {
+        load();
       }
     });
-    node.children.forEach((node) => _displayTree(node, container, parentSelected || isSelected, trail));
-    parentElement.appendChild(container);
   }
-  function _checkNode(node) {
-    const formElement = node.formElement;
-    if(formElement)
-      node.formElement.querySelector('input[type="checkbox"]').checked = true;
-  }
-  function _uncheckNode(node) {
-    const formElement = node.formElement;
-    if(formElement)
-      node.formElement.querySelector('input[type="checkbox"]').checked = false;
-  }
-  function _uncheckAllParents(node) {
-    node.parents.forEach((parentNode) => {
-      _uncheckNode(parentNode);
-      _uncheckAllParents(parentNode);
-    });
-  }
-  function _checkAllChildren(node) {
-    node.children.forEach((childNode) => {
-      _checkNode(childNode);
-      _checkAllChildren(childNode);
-    });
-  }
-  function _uncheckAllChildren(node) {
-    node.children.forEach((childNode) => {
-      _uncheckNode(childNode);
-      _uncheckAllChildren(childNode);
-    });
-  }
-  function _load() {
-    loadRequested = true;
-    const loaderDiv = document.createElement('div');
-    loaderDiv.innerHTML = drupal.theme.ajaxProgressThrobber();
-    containerElement.insertBefore(loaderDiv, containerElement.childNodes[0]);
-    checkboxesElement.innerHTML = '';
-    fetch(baseURI + path)
-      .then((response) => response.json())
-      .then((data) => _buildTree(data))
-      .then((tree) => _sortTree(tree))
-      .then((tree) => {
-        tree.children.forEach((node) => _displayTree(node, checkboxesElement, false, '0'));
-        containerElement.removeChild(loaderDiv);
-        loadComplete = true;
-      });
-  }
-  if(configuration['enabled'] || showAllElement.checked)
-    _load();
-  else {
-    showAllElement.addEventListener('change', function(event) {
-      if(!loadRequested && event.currentTarget.checked)
-        _load();
-    });
-  }
+
 }

--- a/js/cuboulder-today-filter-form-loader.js
+++ b/js/cuboulder-today-filter-form-loader.js
@@ -339,7 +339,7 @@ function cuboulderTodayFilterFormLoader(drupal, baseURL, label, taxonomy, machin
    *   The root node of the taxonomy tree.
    */
   async function legacyLoadTree() {
-    const response = await fetch(baseURL + 'syndicate/article/options/' + taxonomy);
+    const response = await fetch(baseURL + '/syndicate/article/options/' + taxonomy);
     const data = await response.json();
 
     const root = createRootNode(), tidMap = new Map();

--- a/js/cuboulder-today-filter-form-loader.js
+++ b/js/cuboulder-today-filter-form-loader.js
@@ -210,6 +210,7 @@ function cuboulderTodayFilterFormLoader(drupal, label, taxonomy, machineName, co
    *
    * @param {string} apiURL
    *   The url of the API.
+   *
    * @returns
    *   The raw data from the API.
    */

--- a/js/cuboulder-today-filter-form-loader.js
+++ b/js/cuboulder-today-filter-form-loader.js
@@ -21,7 +21,7 @@
  *   The Drupal JavaScript API.
  * @param {string} label
  *   The display label of the filter.
- * @param {string} taxonomy 
+ * @param {string} taxonomy
  *   The name of the taxonomy term this filter is associated with.
  * @param {string} machineName
  *   The machine name of the filter.

--- a/js/cuboulder-today-filter-form-loader.js
+++ b/js/cuboulder-today-filter-form-loader.js
@@ -37,7 +37,7 @@ function cuboulderTodayFilterFormLoader(drupal, baseURL, label, taxonomy, machin
     checkboxesElement = containerElement.querySelector('div'),
     // Stores the HTML of a checkbox to duplicate it later.
     checkboxElementHTML = checkboxesElement.innerHTML,
-    showAllElement = document.getElementById('cuboulder_today_filter_form_enable_' + machineName);
+    showAllElement = document.querySelector(`.cuboulder-today-filter-form-enable[data-filter=${machineName}]`);
   let loadRequested = false, loadComplete = false;
 
   /**

--- a/js/ucb-campus-news.js
+++ b/js/ucb-campus-news.js
@@ -37,8 +37,8 @@
       params.append('unit', audienceFilter.join(' '));
     }
 
-    const paramsString = `${params}`;
-    return `/syndicate/article/read${paramsString ? `?${paramsString}` : ''}`;
+    const paramsString = params.toString();
+    return `/syndicate${paramsString ? `?${paramsString}` : ''}`;
   }
 
   /**
@@ -238,7 +238,8 @@
     });
 
     dataArr.sort((a, b) =>
-      parseFloat(b.created.getMilliseconds()) - parseFloat(a.created.getMilliseconds()));
+      parseFloat(b.created.getMilliseconds()) - parseFloat(a.created.getMilliseconds())
+    );
 
     return {
       articleHTML: dataArr,
@@ -378,9 +379,7 @@
      */
     renderTeaser(data, readMoreURL, itemCount) {
       // Iterate through response object
-      for (let i = 0; i < Math.min(itemCount, data.length); i++) {
-        const article = data[i];
-
+      data.forEach(article => {
         // Date conversion
         const fullDate = article.created;
         const month = fullDate.toLocaleDateString('en-us', { month: 'short' });
@@ -399,7 +398,7 @@
 
         // Append
         this.appendChild(articleContainer);
-      }
+      });
 
       // After articles, create Read More link
       const readMoreContainer = document.createElement('div');
@@ -429,8 +428,7 @@
       const gridContainer = document.createElement('div');
       gridContainer.className = 'row';
       // Iterate
-      for (let i = 0; i < Math.min(itemCount, data.length); i++) {
-        const article = data[i];
+      data.forEach(article => {
         // Create article container
         const articleContainer = document.createElement('div');
         articleContainer.className = 'campus-news-article-grid col-sm-12 col-md-6 col-lg-4';
@@ -447,7 +445,7 @@
           const absoluteURL = `https://www.colorado.edu/today/${relativeURL}`;
           moreLinkElement.href = absoluteURL;
         }
-      }
+      });
       // Append grid
       this.appendChild(gridContainer);
 
@@ -477,15 +475,14 @@
      */
     renderTitle(data, readMoreURL, itemCount) {
       // Iterate
-      for (let i = 0; i < Math.min(itemCount, data.length); i++) {
-        const article = data[i];
+      data.forEach(article => {
         // Create article container
         const articleContainer = document.createElement('div');
         articleContainer.className = 'ucb-campus-news-title-only';
         articleContainer.innerHTML += article.title;
         // Append
         this.appendChild(articleContainer);
-      }
+      });
       const readMoreContainer = document.createElement('div');
       readMoreContainer.className = 'ucb-campus-news-link-container';
       // After articles, create Read More link
@@ -513,8 +510,7 @@
      */
     renderTitleThumbnail(data, readMoreURL, itemCount) {
       // Iterate
-      for (let i = 0; i < Math.min(itemCount, data.length); i++) {
-        const article = data[i];
+      data.forEach(article => {
         // Create article container
         const articleContainer = document.createElement('div');
         articleContainer.className = 'ucb-campus-news-title-thumbnail-only d-flex';
@@ -523,7 +519,7 @@
 
         // Append
         this.appendChild(articleContainer);
-      }
+      });
 
       const readMoreContainer = document.createElement('div');
       readMoreContainer.className = 'ucb-campus-news-link-container';
@@ -558,7 +554,7 @@
 
         // Render number specified by user
         // First pass generate the feature block, setup the containers
-        if (this.children.length - 1 == 0) {
+        if (i == 0) {
           // Create article container
           const featureContainer = document.createElement('div');
           featureContainer.className = 'campus-news-article-feature col-lg-8 col-md-8 col-sm-8 col-xs-12';

--- a/js/ucb-campus-news.js
+++ b/js/ucb-campus-news.js
@@ -379,7 +379,9 @@
      */
     renderTeaser(data, readMoreURL, itemCount) {
       // Iterate through response object
-      data.forEach(article => {
+      for (let i = 0; i < Math.min(itemCount, data.length); i++) {
+        const article = data[i];
+
         // Date conversion
         const fullDate = article.created;
         const month = fullDate.toLocaleDateString('en-us', { month: 'short' });
@@ -398,7 +400,7 @@
 
         // Append
         this.appendChild(articleContainer);
-      });
+      }
 
       // After articles, create Read More link
       const readMoreContainer = document.createElement('div');
@@ -428,7 +430,8 @@
       const gridContainer = document.createElement('div');
       gridContainer.className = 'row';
       // Iterate
-      data.forEach(article => {
+      for (let i = 0; i < Math.min(itemCount, data.length); i++) {
+        const article = data[i];
         // Create article container
         const articleContainer = document.createElement('div');
         articleContainer.className = 'campus-news-article-grid col-sm-12 col-md-6 col-lg-4';
@@ -445,7 +448,7 @@
           const absoluteURL = `https://www.colorado.edu/today/${relativeURL}`;
           moreLinkElement.href = absoluteURL;
         }
-      });
+      }
       // Append grid
       this.appendChild(gridContainer);
 
@@ -475,14 +478,15 @@
      */
     renderTitle(data, readMoreURL, itemCount) {
       // Iterate
-      data.forEach(article => {
+      for (let i = 0; i < Math.min(itemCount, data.length); i++) {
+        const article = data[i];
         // Create article container
         const articleContainer = document.createElement('div');
         articleContainer.className = 'ucb-campus-news-title-only';
         articleContainer.innerHTML += article.title;
         // Append
         this.appendChild(articleContainer);
-      });
+      }
       const readMoreContainer = document.createElement('div');
       readMoreContainer.className = 'ucb-campus-news-link-container';
       // After articles, create Read More link
@@ -510,7 +514,8 @@
      */
     renderTitleThumbnail(data, readMoreURL, itemCount) {
       // Iterate
-      data.forEach(article => {
+      for (let i = 0; i < Math.min(itemCount, data.length); i++) {
+        const article = data[i];
         // Create article container
         const articleContainer = document.createElement('div');
         articleContainer.className = 'ucb-campus-news-title-thumbnail-only d-flex';
@@ -519,7 +524,7 @@
 
         // Append
         this.appendChild(articleContainer);
-      });
+      }
 
       const readMoreContainer = document.createElement('div');
       readMoreContainer.className = 'ucb-campus-news-link-container';

--- a/js/ucb-campus-news.js
+++ b/js/ucb-campus-news.js
@@ -1,389 +1,529 @@
-class CampusNewsElement extends HTMLElement {
-  constructor() {
-    super();
+/**
+ * @file Contains the frontend for the Campus News block.
+ *
+ * @typedef {{
+ *   title: string;
+ *   thumbnail: string;
+ *   body: string;
+ *   created: number;
+ * }} ArticleHtml
+ */
 
-    this.renderLoader(false);
-    let renderStyle = this.getAttribute('rendermethod');
-    const dataFilters = this.getAttribute('filters');
-    const itemCount = parseInt(this.getAttribute('count')) + 3;
-    const dataFiltersJSON = JSON.parse(dataFilters);
+(function (customElements) {
 
-    // Only a 0 in the array means no filters selected, if array only contains a 0, remove it and set an empty array.
-    const categories = dataFiltersJSON.categories.filter((id) => id != 0);
-    const audience = dataFiltersJSON.audiences.filter((id) => id != 0);
-    const syndicationUnit = dataFiltersJSON.units.filter((id) => id != 0);
+  /**
+   * Fetches the articles using the Today site JSON API.
+   *
+   * @param {number[]} categoryFilter
+   *   The category filter from the block configuration.
+   * @param {number[]} audienceFilter
+   *   The syndication audience filter from the block configuration.
+   * @param {number[]} unitFilter
+   *   The syndication unit filter from the block configuration.
+   * @param {string} renderStyle
+   *   The render style from the block configuration.
+   *
+   * @returns {{ articleHtml: ArticleHtml[]; readMoreUrl: string }}
+   *   The resulting article HTML based on the render style, and the correct
+   *   read more link URL for this version of the Today site.
+   */
+  async function jsonAPILoadArticles(categoryFilter, audienceFilter, unitFilter, renderStyle) {
+    // TODO: JSON API client.
+    throw new Error('JSON API client not yet implemented.');
+  }
 
+  /**
+   * Fetches the articles using the legacy (Drupal 7) Today site API.
+   *
+   * @param {number[]} categoryFilter
+   *   The category filter from the block configuration.
+   * @param {number[]} audienceFilter
+   *   The syndication audience filter from the block configuration.
+   * @param {number[]} unitFilter
+   *   The syndication unit filter from the block configuration.
+   * @param {string} renderStyle
+   *   The render style from the block configuration.
+   *
+   * @returns {{ articleHtml: ArticleHtml[]; readMoreUrl: string }}
+   *   The resulting article HTML based on the render style, and the correct
+   *   read more link URL for this version of the Today site.
+   */
+  async function legacyLoadArticles(categoryFilter, audienceFilter, unitFilter, renderStyle) {
     // Construct the URL
-    // Build parameter strings, if respective filter array is not empty. Each array contains ID's and builds each section of the filter piece
+    // Build parameter strings, if respective filter array is not empty. Each
+    // array contains ID's and builds each section of the filter piece
     // Format => '?parameter=id+id'
-    const categoryParam = categories.length === 0 ? '' : `category=${categories.join('%2B')}`;
-    const audienceParam = audience.length === 0 ? '' : `audience=${audience.join('%2B')}`;
-    const syndicationUnitParam = syndicationUnit.length === 0 ? '' : `unit=${syndicationUnit.join('%2B')}`;
+    const categoryParam = categoryFilter.length === 0 ? '' : `category=${categoryFilter.join('%2B')}`;
+    const audienceParam = audienceFilter.length === 0 ? '' : `audience=${audienceFilter.join('%2B')}`;
+    const unitParam = unitFilter.length === 0 ? '' : `unit=${unitFilter.join('%2B')}`;
 
     const baseURL = 'https://www.colorado.edu/today/syndicate/article';
     // Adds in filter parameters for API request
     let filterUrl = '';
 
-    // Conditional statements for building the API parameter piece of the endpoint
+    // Conditional statements for building the API parameter piece of the
+    // endpoint
     if (categoryParam != '') {
       filterUrl += '?' + categoryParam;
     }
 
-    // These statements adjust the parameter piece of the URL depending on what 
-    if (categoryParam === '' && audienceParam != '') {
+    // These statements adjust the parameter piece of the URL depending on what
+    if (categoryParam == '' && audienceParam != '') {
       filterUrl += '?' + audienceParam;
     } else if (audienceParam != '') {
       filterUrl += `&${audienceParam}`;
     }
 
-    if (categoryParam == '' && audienceParam == '' && syndicationUnitParam != '') {
-      filterUrl += '?' + syndicationUnitParam;
-    } else if (syndicationUnitParam != '' && (categoryParam != '' || audienceParam != '')) {
-      filterUrl += `&${syndicationUnitParam}`;
-    } else {
-      // Do nothing
+    if (categoryParam == '' && audienceParam == '' && unitParam != '') {
+      filterUrl += '?' + unitParam;
+    } else if (unitParam != '' && (categoryParam != '' || audienceParam != '')) {
+      filterUrl += `&${unitParam}`;
     }
 
-    // This condition enables grid mode to pull the wide thumbnails for styling in grid mode, otherwise just grab thumbnails
-    let API = baseURL + filterUrl
+    // This condition enables grid mode to pull the wide thumbnails for
+    // styling in grid mode, otherwise just grab thumbnails
+    let api = baseURL + filterUrl
     if (renderStyle === '1') {
-      if (categoryParam == '' && audienceParam == '' && syndicationUnitParam == '') {
-        API += '?view_mode=grid';
+      if (categoryParam == '' && audienceParam == '' && unitParam == '') {
+        api += '?view_mode=grid';
       } else {
-        API += '&view_mode=grid';
+        api += '&view_mode=grid';
       }
     }
 
-    // This condition enables Feature Block to pull the widest thumbnails for styling
+    // This condition enables Feature Block to pull the widest thumbnails for
+    // styling
     if (renderStyle === '4') {
-      if (categoryParam == '' && audienceParam == '' && syndicationUnitParam == '') {
-        API += '?view_mode=feature';
+      if (categoryParam == '' && audienceParam == '' && unitParam == '') {
+        api += '?view_mode=feature';
       } else {
-        API += '&view_mode=feature';
+        api += '&view_mode=feature';
       }
     }
-    // Fetch final URL, render in requested renderStyle
-    /*
-    * 0 - Teaser
-    * 1 - Grid
-    * 2 - Title & Thumbnail
-    * 3 - Title Only
-    * 4 - Feature Block
-    */
-    fetch(API).then((response) => response.json()).then((data) => {
 
-      // Convert to array and sort by created
-      const dataArr = Object.keys(data).map(key => {
-        return data[key];
-      });
-      dataArr.sort((a, b) => parseFloat(b.created) - parseFloat(a.created));
+    const data = await fetch(api);
+    const json = await data.json();
+
+    // Convert to array and sort by created
+    const dataArr = Object.keys(json).map(key => {
+      const article = json[key];
+      return {
+        title: article['title'],
+        thumbnail: article['thumbnail'],
+        body: article['body'],
+        created: article['created']
+      };
+    });
+    dataArr.sort((a, b) => parseFloat(b.created) - parseFloat(a.created));
+
+    return {
+      articleHtml: dataArr,
+      readMoreUrl: 'https://www.colorado.edu/today/syndicate/article/read' + filterUrl
+    };
+  }
+
+  /**
+   * Defines a web component to display a Campus News block.
+   */
+  class CampusNewsElement extends HTMLElement {
+
+    /**
+     * Constructs a CampusNewsElement.
+     */
+    constructor() {
+      super();
+      this.loadArticles();
+    }
+
+    /**
+     * Loads all articles for this Campus News block.
+     */
+    async loadArticles() {
+      this.renderLoader(false);
+      let renderStyle = this.getAttribute('rendermethod');
+      const dataFilters = this.getAttribute('filters');
+      const itemCount = parseInt(this.getAttribute('count')) + 3;
+      const dataFiltersJSON = JSON.parse(dataFilters);
+
+      // Only a 0 in the array means no filters selected, if array only
+      // contains a 0, remove it and set an empty array.
+      const categoryFilter = dataFiltersJSON.categories.filter(id => id != 0);
+      const audienceFilter = dataFiltersJSON.audiences.filter(id => id != 0);
+      const unitFilter = dataFiltersJSON.units.filter(id => id != 0);
+
+      // Fetch final URL, render in requested renderStyle
+      /*
+      * 0 - Teaser
+      * 1 - Grid
+      * 2 - Title & Thumbnail
+      * 3 - Title Only
+      * 4 - Feature Block
+      */
+      let data;
+      try {
+        data = await jsonAPILoadArticles(categoryFilter, audienceFilter, unitFilter, renderStyle);
+      } catch (exception) {
+        console.error(exception);
+        console.warn('Call to JSON API failed, trying legacy API.');
+        try {
+          data = await legacyLoadArticles(categoryFilter, audienceFilter, unitFilter, renderStyle);
+        } catch (exception2) {
+          console.error(exception2);
+          // If API error, render Read More @ Today link with Error Message
+          const errorHeader = document.createElement('h4');
+          errorHeader.innerText = 'Unable to load articles - please try again later';
+          const readMoreContainer = document.createElement('div')
+          readMoreContainer.classList = 'ucb-campus-news-grid-link-container';
+          const readMoreLink = document.createElement('a');
+          readMoreLink.classList = 'ucb-campus-news-grid-link';
+          readMoreLink.href = 'https://www.colorado.edu/today/syndicate/article/read';
+          readMoreLink.innerText = 'Read on CU Boulder Today';
+
+          // Append
+          readMoreContainer.appendChild(errorHeader);
+          readMoreContainer.appendChild(readMoreLink);
+          this.appendChild(readMoreContainer);
+        }
+      }
 
       // Error - no data
-      if (dataArr.length === 0) {
+      if (data.articleHtml.length === 0) {
         renderStyle = 'error';
       }
 
-      // BUILD
-      this.build(dataArr, renderStyle, filterUrl, itemCount);
+      this.render(data.articleHtml, renderStyle, data.readMoreUrl, itemCount);      
+    }
 
-    }).catch((error) => {
-      console.error(error);
-      // If API error, render Read More @ Today link with Error Message
-      const errorHeader = document.createElement('h4');
-      errorHeader.innerText = 'Unable to load articles - please try again later';
-      const readMoreContainer = document.createElement('div')
+    /**
+     * Renders this Campus News block.
+     *
+     * @param {ArticleHtml[]} dataArr
+     *   The resulting article HTML based on the render style.
+     * @param {string} renderStyle
+     *   The render style from the block configuration.
+     * @param {string} readMoreUrl
+     *   The correct read more link URL for this version of the Today site.
+     * @param {number} itemCount
+     *   The maximum number of articles to display from the block
+     *   configuration.
+     */
+    render(dataArr, renderStyle, readMoreUrl, itemCount) {
+      this.renderLoader(true)
+
+      switch (renderStyle) {
+        case '0':
+          this.renderTeaser(dataArr, readMoreUrl, itemCount);
+          break;
+
+        case '1':
+          this.renderGrid(dataArr, readMoreUrl, itemCount);
+          break;
+
+        case '2':
+          this.renderTitleThumbnail(dataArr, readMoreUrl, itemCount);
+          break;
+
+        case '3':
+          this.renderTitle(dataArr, readMoreUrl, itemCount);
+          break;
+
+        case '4':
+          this.renderFeature(dataArr, readMoreUrl, itemCount);
+          break;
+
+        case 'error':
+          this.renderNoResultsError();
+          break;
+
+        default:
+          this.renderTeaser(dataArr, readMoreUrl, itemCount);
+      }
+    }
+
+    /**
+     * Renders this Campus News block based on the Teaser render style.
+     *
+     * @param {ArticleHtml[]} data
+     *   The resulting article HTML based on the render style.
+     * @param {string} readMoreUrl
+     *   The correct read more link URL for this version of the Today site.
+     * @param {number} itemCount
+     *   The maximum number of articles to display from the block
+     *   configuration.
+     */
+    renderTeaser(data, readMoreUrl, itemCount) {
+      // Iterate through response object
+      data.forEach(article => {
+        // Render number specifed by user
+        if (itemCount > this.children.length - 1) {
+          // Date conversion
+          const fullDate = new Date(parseInt(article.created) * 1000);
+          const month = fullDate.toLocaleDateString('en-us', { month: 'short' });
+          const day = fullDate.getUTCDate();
+          const year = fullDate.getUTCFullYear();
+
+          // Create article container
+          const articleContainer = document.createElement('div');
+          articleContainer.classList = 'campus-news-article-teaser d-flex';
+          articleContainer.innerHTML = article.thumbnail;
+          const articleContainerText = document.createElement('div');
+          articleContainerText.innerHTML += article.title;
+          articleContainerText.innerHTML += `<p class="ucb-campus-news-date">${month == 'May' ? month : month + '.'} ${day}, ${year}</p>`;
+          articleContainerText.innerHTML += article.body;
+          articleContainer.appendChild(articleContainerText);
+
+          // Hide loader
+          this.renderLoader(false);
+          // Append
+          this.appendChild(articleContainer);
+        }
+      });
+
+      // After articles, create Read More link
+      const readMoreContainer = document.createElement('div');
+      readMoreContainer.classList = 'ucb-campus-news-link-container';
+      const readMoreLink = document.createElement('a');
+      readMoreLink.classList = 'ucb-campus-news-link';
+      readMoreLink.href = readMoreUrl;
+      readMoreLink.innerText = 'Read more at CU Boulder Today';
+      readMoreContainer.appendChild(readMoreLink);
+
+      // Append
+      this.appendChild(readMoreContainer);
+    }
+
+    /**
+     * Renders this Campus News block based on the Grid render style.
+     *
+     * @param {ArticleHtml[]} data
+     *   The resulting article HTML based on the render style.
+     * @param {string} readMoreUrl
+     *   The correct read more link URL for this version of the Today site.
+     * @param {number} itemCount
+     *   The maximum number of articles to display from the block
+     *   configuration.
+     */
+    renderGrid(data, readMoreUrl, itemCount) {
+      const gridContainer = document.createElement('div');
+      gridContainer.classList = 'row';
+      // Iterate
+      data.forEach(article => {
+        // Render number specified by user
+        if (itemCount > gridContainer.children.length) {
+          // Create article container
+          const articleContainer = document.createElement('div');
+          articleContainer.classList = 'campus-news-article-grid col-sm-12 col-md-6 col-lg-4';
+          articleContainer.innerHTML = article.thumbnail;
+          articleContainer.innerHTML += article.title;
+          articleContainer.innerHTML += article.body;
+
+          // Append
+          gridContainer.appendChild(articleContainer)
+          // Fix relative URL on Read More Grid link
+          const relativeURL = articleContainer.getElementsByClassName('more-link')[0].href.split('/today/')[1];
+          const absoluteURL = `https://www.colorado.edu/today/${relativeURL}`;
+          articleContainer.getElementsByClassName('more-link')[0].href = absoluteURL;
+        }
+      });
+      // Hide loader
+      this.renderLoader(false);
+      // Append grid
+      this.appendChild(gridContainer);
+
+      // After articles, create Read More link (Grid style)
+      const readMoreContainer = document.createElement('div');
       readMoreContainer.classList = 'ucb-campus-news-grid-link-container';
       const readMoreLink = document.createElement('a');
       readMoreLink.classList = 'ucb-campus-news-grid-link';
-      // Adds filter choices to Read More Link
-      readMoreLink.href = 'https://www.colorado.edu/today/syndicate/article/read';
-      if (filterUrl != '') {
-        readMoreLink.href += filterUrl;
-      }
-      readMoreLink.innerText = 'Read on CU Boulder Today';
+      readMoreLink.href = readMoreUrl;
+      readMoreLink.innerText = 'Read more at CU Boulder Today';
 
       // Append
-      readMoreContainer.appendChild(errorHeader);
       readMoreContainer.appendChild(readMoreLink);
       this.appendChild(readMoreContainer);
-    });
-  }
-
-  // BUILD
-  build(dataArr, renderStyle, filterUrl, itemCount) {
-    this.renderLoader(true)
-
-    switch (renderStyle) {
-      case '0':
-        this.renderTeaser(dataArr, filterUrl, itemCount);
-        break;
-
-      case '1':
-        this.renderGrid(dataArr, filterUrl, itemCount);
-        break;
-
-      case '2':
-        this.renderTitleThumbnail(dataArr, filterUrl, itemCount);
-        break;
-
-      case '3':
-        this.renderTitle(dataArr, filterUrl, itemCount);
-        break;
-
-      case '4':
-        this.renderFeature(dataArr, filterUrl, itemCount);
-        break;
-
-      case 'error':
-        this.renderError()
-
-      default:
-        this.renderTeaser(dataArr, filterUrl, itemCount);
-        break;
     }
-  }
 
-  // Render as Teasers
-  renderTeaser(data, filterUrl, itemCount) {
-    // Iterate through response object
-    data.forEach(article => {
-      // Render number specifed by user
-      if (itemCount > this.children.length - 1) {
-        // Date conversion
-        const fullDate = new Date(parseInt(article.created) * 1000);
-        const month = fullDate.toLocaleDateString('en-us', { month: 'short' });
-        const day = fullDate.getUTCDate();
-        const year = fullDate.getUTCFullYear();
-
-        // Create article container
-        const articleContainer = document.createElement('div');
-        articleContainer.classList = 'campus-news-article-teaser d-flex';
-        articleContainer.innerHTML = article.thumbnail;
-        const articleContainerText = document.createElement('div');
-        articleContainerText.innerHTML += article.title;
-        articleContainerText.innerHTML += `<p class="ucb-campus-news-date">${month == 'May' ? month : month + '.'} ${day}, ${year}</p>`;
-        articleContainerText.innerHTML += article.body;
-        articleContainer.appendChild(articleContainerText);
-
-        // Hide loader
-        this.renderLoader(false);
-        // Append
-        this.appendChild(articleContainer);
-      }
-    });
-
-    // After articles, create Read More link
-    const readMoreContainer = document.createElement('div');
-    readMoreContainer.classList = 'ucb-campus-news-link-container';
-    const readMoreLink = document.createElement('a');
-    readMoreLink.classList = 'ucb-campus-news-link';
-    readMoreLink.href = 'https://www.colorado.edu/today/syndicate/article/read';
-    // Adds filter choices to Read More Link
-    if (filterUrl != '') {
-      readMoreLink.href += filterUrl;
-    }
-    readMoreLink.innerText = 'Read more at CU Boulder Today';
-    readMoreContainer.appendChild(readMoreLink);
-
-    // Append
-    this.appendChild(readMoreContainer);
-
-  }
-  // Render as Grid
-  renderGrid(data, filterUrl, itemCount) {
-    const gridContainer = document.createElement('div');
-    gridContainer.classList = 'row';
-    // Iterate
-    data.forEach(article => {
-      // Render number specified by user
-      if (itemCount > gridContainer.children.length) {
-        // Create article container
-        const articleContainer = document.createElement('div');
-        articleContainer.classList = 'campus-news-article-grid col-sm-12 col-md-6 col-lg-4';
-        articleContainer.innerHTML = article.thumbnail;
-        articleContainer.innerHTML += article.title;
-        articleContainer.innerHTML += article.body;
-
-        // Append
-        gridContainer.appendChild(articleContainer)
-        // Fix relative URL on Read More Grid link
-        const relativeURL = articleContainer.getElementsByClassName('more-link')[0].href.split('/today/')[1];
-        const absoluteURL = `https://www.colorado.edu/today/${relativeURL}`;
-        articleContainer.getElementsByClassName('more-link')[0].href = absoluteURL;
-      }
-    });
-    // Hide loader
-    this.renderLoader(false);
-    // Append grid
-    this.appendChild(gridContainer);
-
-    // After articles, create Read More link (Grid style)
-    const readMoreContainer = document.createElement('div');
-    readMoreContainer.classList = 'ucb-campus-news-grid-link-container';
-    const readMoreLink = document.createElement('a');
-    readMoreLink.classList = 'ucb-campus-news-grid-link';
-    // Adds filter choices to Read More Link
-    readMoreLink.href = 'https://www.colorado.edu/today/syndicate/article/read';
-    if (filterUrl != '') {
-      readMoreLink.href += filterUrl;
-    }
-    readMoreLink.innerText = 'Read more at CU Boulder Today';
-
-    // Append
-    readMoreContainer.appendChild(readMoreLink);
-    this.appendChild(readMoreContainer);
-  }
-  // Render as Title Only
-  renderTitle(data, filterUrl, itemCount) {
-    // Iterate
-    data.forEach(article => {
-      // Render number specified by user
-      if (itemCount > this.children.length - 1) {
-        // Create article container
-        const articleContainer = document.createElement('div');
-        articleContainer.classList = 'ucb-campus-news-title-only';
-        articleContainer.innerHTML += article.title;
-        // Hide loader
-        this.renderLoader(false);
-        // Append
-        this.appendChild(articleContainer);
-      }
-    });
-    const readMoreContainer = document.createElement('div');
-    readMoreContainer.classList = 'ucb-campus-news-link-container';
-    // After articles, create Read More link
-    const readMoreLink = document.createElement('a');
-    readMoreLink.classList = 'ucb-campus-news-link';
-    readMoreLink.href = 'https://www.colorado.edu/today/syndicate/article/read';
-    // Adds filter choices to Read More Link
-    if (filterUrl != '') {
-      readMoreLink.href += filterUrl;
-    }
-    readMoreLink.innerText = 'Read more at CU Boulder Today';
-    readMoreContainer.appendChild(readMoreLink);
-
-    // Append
-    this.appendChild(readMoreContainer);
-  }
-  // Render as Title and Thumbnail
-  renderTitleThumbnail(data, filterUrl, itemCount) {
-    // Iterate
-    data.forEach(article => {
-      // Render number specified by user
-      if (itemCount > this.children.length - 1) {
-        // Create article container
-        const articleContainer = document.createElement('div');
-        articleContainer.classList = 'ucb-campus-news-title-thumbnail-only d-flex';
-        articleContainer.innerHTML = article.thumbnail;
-        articleContainer.innerHTML += article.title;
-
-        // Hide loader and Append
-        this.renderLoader(false);
-        this.appendChild(articleContainer);
-      }
-    });
-
-    const readMoreContainer = document.createElement('div')
-    readMoreContainer.classList = 'ucb-campus-news-link-container';
-    // After articles, create Read More link
-    const readMoreLink = document.createElement('a');
-    readMoreLink.classList = 'ucb-campus-news-link';
-    readMoreLink.href = 'https://www.colorado.edu/today/syndicate/article/read';
-    // Adds filter choices to Read More Link
-    if (filterUrl != '') {
-      readMoreLink.href += filterUrl;
-    }
-    readMoreLink.innerText = 'Read more at CU Boulder Today';
-    readMoreContainer.appendChild(readMoreLink);
-
-    // Append
-    this.appendChild(readMoreContainer);
-  }
-  // Render as Feature Block
-  renderFeature(data, filterUrl, itemCount) {
-    const featureBlockContainer = document.createElement('div');
-    featureBlockContainer.classList = 'row';
-    // Iterate
-    data.forEach(article => {
-      // Render number specified by user
-      // First pass generate the feature block, setup the containers
-      if (this.children.length - 1 == 0) {
-        // Create article container
-        const featureContainer = document.createElement('div');
-        featureContainer.classList = 'campus-news-article-feature col-lg-8 col-md-8 col-sm-8 col-xs-12';
-        featureContainer.innerHTML = article.thumbnail;
-        featureContainer.innerHTML += article.title;
-        featureContainer.innerHTML += article.body;
-
-        // Create Button 
-        const readMoreLink = document.createElement('a');
-        readMoreLink.classList = 'ucb-campus-news-grid-link mt-5';
-        // Adds filter choices to Read More Link
-        readMoreLink.href = 'https://www.colorado.edu/today/syndicate/article/read';
-        if (filterUrl != '') {
-          readMoreLink.href += filterUrl;
+    /**
+     * Renders this Campus News block based on the Title render style.
+     *
+     * @param {ArticleHtml[]} data
+     *   The resulting article HTML based on the render style.
+     * @param {string} readMoreUrl
+     *   The correct read more link URL for this version of the Today site.
+     * @param {number} itemCount
+     *   The maximum number of articles to display from the block
+     *   configuration.
+     */
+    renderTitle(data, readMoreUrl, itemCount) {
+      // Iterate
+      data.forEach(article => {
+        // Render number specified by user
+        if (itemCount > this.children.length - 1) {
+          // Create article container
+          const articleContainer = document.createElement('div');
+          articleContainer.classList = 'ucb-campus-news-title-only';
+          articleContainer.innerHTML += article.title;
+          // Hide loader
+          this.renderLoader(false);
+          // Append
+          this.appendChild(articleContainer);
         }
-        readMoreLink.innerText = 'Read more at CU Boulder Today';
+      });
+      const readMoreContainer = document.createElement('div');
+      readMoreContainer.classList = 'ucb-campus-news-link-container';
+      // After articles, create Read More link
+      const readMoreLink = document.createElement('a');
+      readMoreLink.classList = 'ucb-campus-news-link';
+      readMoreLink.href = readMoreUrl;
+      readMoreLink.innerText = 'Read more at CU Boulder Today';
+      readMoreContainer.appendChild(readMoreLink);
 
-        // Append
-        featureContainer.appendChild(readMoreLink);
+      // Append
+      this.appendChild(readMoreContainer);
+    }
 
-        // Append
-        featureBlockContainer.appendChild(featureContainer);
-        this.appendChild(featureBlockContainer);
-
-        // Create the subfeature container
-        const remainingFeatureContainer = document.createElement('div');
-        remainingFeatureContainer.classList = 'article-feature-block-remaining col-lg-4 col-md-4 col-sm-4 col-xs-12';
-        remainingFeatureContainer.id = 'remaining-feature-container';
-        // Append & Hide Loader
-        this.renderLoader(false);
-        featureBlockContainer.appendChild(remainingFeatureContainer);
-      } else {
-        if (itemCount > this.children[1].children[1].children.length + 1) {
-
+    /**
+     * Renders this Campus News block based on the Title and Thumbnail render
+     * style.
+     *
+     * @param {ArticleHtml[]} data
+     *   The resulting article HTML based on the render style.
+     * @param {string} readMoreUrl
+     *   The correct read more link URL for this version of the Today site.
+     * @param {number} itemCount
+     *   The maximum number of articles to display from the block
+     *   configuration.
+     */
+    renderTitleThumbnail(data, readMoreUrl, itemCount) {
+      // Iterate
+      data.forEach(article => {
+        // Render number specified by user
+        if (itemCount > this.children.length - 1) {
           // Create article container
           const articleContainer = document.createElement('div');
           articleContainer.classList = 'ucb-campus-news-title-thumbnail-only d-flex';
           articleContainer.innerHTML = article.thumbnail;
           articleContainer.innerHTML += article.title;
 
-          // Append
-          this.children[1].children[1].appendChild(articleContainer);
+          // Hide loader and Append
+          this.renderLoader(false);
+          this.appendChild(articleContainer);
         }
-      }
-    })
-  }
-  // Error - no results from API
-  renderError() {
-    // Create error message
-    const errorContainer = document.createElement('div');
-    errorContainer.classList = 'ucb-campus-news-error-container';
-    const errorMessage = document.createElement('h3');
-    errorMessage.classList = 'ucb-campus-news-error-message';
+      });
 
-    errorMessage.innerText = 'Error retrieving results from Colorado Today - check filters and try again';
-    // Remove loader, render error
-    this.renderLoader(false);
-    // Append
-    errorContainer.appendChild(errorMessage);
-    this.appendChild(errorContainer);
+      const readMoreContainer = document.createElement('div')
+      readMoreContainer.classList = 'ucb-campus-news-link-container';
+      // After articles, create Read More link
+      const readMoreLink = document.createElement('a');
+      readMoreLink.classList = 'ucb-campus-news-link';
+      readMoreLink.href = readMoreUrl;
+      readMoreLink.innerText = 'Read more at CU Boulder Today';
+      readMoreContainer.appendChild(readMoreLink);
 
-    // Remove Read More Link
-    this.children.length = 2;
-
-  }
-  // Render Loader
-  renderLoader(bool) {
-    const loader = this.getElementsByClassName('ucb-list-msg ucb-loading-data')[0];
-
-    if (bool) {
-      loader.style.display = 'block';
-    } else {
-      loader.style.display = 'none';
+      // Append
+      this.appendChild(readMoreContainer);
     }
 
-  }
-}
+    /**
+     * Renders this Campus News block based on the Feature render style.
+     *
+     * @param {ArticleHtml[]} data
+     *   The resulting article HTML based on the render style.
+     * @param {string} readMoreUrl
+     *   The correct read more link URL for this version of the Today site.
+     * @param {number} itemCount
+     *   The maximum number of articles to display from the block
+     *   configuration.
+     */
+    renderFeature(data, readMoreUrl, itemCount) {
+      const featureBlockContainer = document.createElement('div');
+      featureBlockContainer.classList = 'row';
+      // Iterate
+      data.forEach(article => {
+        // Render number specified by user
+        // First pass generate the feature block, setup the containers
+        if (this.children.length - 1 == 0) {
+          // Create article container
+          const featureContainer = document.createElement('div');
+          featureContainer.classList = 'campus-news-article-feature col-lg-8 col-md-8 col-sm-8 col-xs-12';
+          featureContainer.innerHTML = article.thumbnail;
+          featureContainer.innerHTML += article.title;
+          featureContainer.innerHTML += article.body;
 
-customElements.define('campus-news', CampusNewsElement);
+          // Create Button 
+          const readMoreLink = document.createElement('a');
+          readMoreLink.classList = 'ucb-campus-news-grid-link mt-5';
+          readMoreLink.href = readMoreUrl;
+          readMoreLink.innerText = 'Read more at CU Boulder Today';
+
+          // Append
+          featureContainer.appendChild(readMoreLink);
+
+          // Append
+          featureBlockContainer.appendChild(featureContainer);
+          this.appendChild(featureBlockContainer);
+
+          // Create the subfeature container
+          const remainingFeatureContainer = document.createElement('div');
+          remainingFeatureContainer.classList = 'article-feature-block-remaining col-lg-4 col-md-4 col-sm-4 col-xs-12';
+          remainingFeatureContainer.id = 'remaining-feature-container';
+          // Append & Hide Loader
+          this.renderLoader(false);
+          featureBlockContainer.appendChild(remainingFeatureContainer);
+        } else {
+          if (itemCount > this.children[1].children[1].children.length + 1) {
+
+            // Create article container
+            const articleContainer = document.createElement('div');
+            articleContainer.classList = 'ucb-campus-news-title-thumbnail-only d-flex';
+            articleContainer.innerHTML = article.thumbnail;
+            articleContainer.innerHTML += article.title;
+
+            // Append
+            this.children[1].children[1].appendChild(articleContainer);
+          }
+        }
+      })
+    }
+
+    /**
+     * Renders an error if there are no results.
+     */
+    renderNoResultsError() {
+      // Create error message
+      const errorContainer = document.createElement('div');
+      errorContainer.classList = 'ucb-campus-news-error-container';
+      const errorMessage = document.createElement('h3');
+      errorMessage.classList = 'ucb-campus-news-error-message';
+
+      errorMessage.innerText = 'Error retrieving results from CU Boulder Today - check filters and try again';
+      // Remove loader, render error
+      this.renderLoader(false);
+      // Append
+      errorContainer.appendChild(errorMessage);
+      this.appendChild(errorContainer);
+
+      // Remove Read More Link
+      this.children.length = 2;
+    }
+
+    /**
+     * Shows or hides the loading spinner.
+     *
+     * @param {boolean} show
+     *   Whether to show or hide the spinner.
+     */
+    renderLoader(show) {
+      const loader = this.getElementsByClassName('ucb-list-msg ucb-loading-data')[0];
+
+      if (show) {
+        loader.style.display = 'block';
+      } else {
+        loader.style.display = 'none';
+      }
+    }
+  }
+
+  customElements.define('campus-news', CampusNewsElement);
+
+})(customElements);

--- a/js/ucb-campus-news.js
+++ b/js/ucb-campus-news.js
@@ -25,12 +25,11 @@
    */
   function jsonAPICreateFilterGroup(params, termIds, groupName, fieldName) {
     if (termIds.length > 0) {
-      params.append(`filter[${groupName}][group][conjunction]`, 'OR');
-      termIds.forEach(termId => {
-        params.append(`filter[${groupName}-${termId}][condition][path]`, `${fieldName}.meta.drupal_internal__target_id`);
-        params.append(`filter[${groupName}-${termId}][condition][value]`, `${termId}`);
-        params.append(`filter[${groupName}-${termId}][condition][memberOf]`, groupName);
-      });
+      params.append(`filter[${groupName}][condition][path]`, `${fieldName}.meta.drupal_internal__target_id`);
+      params.append(`filter[${groupName}][condition][operator]`, 'IN');
+      for (let i = 0; i < termIds.length; i++) {
+        params.append(`filter[${groupName}][condition][value][${i + 1}]`, `${termIds[i]}`);
+      }
     }
   }
 

--- a/js/ucb-campus-news.js
+++ b/js/ucb-campus-news.js
@@ -623,7 +623,6 @@
       readMoreContainer.className = 'ucb-campus-news-grid-link-container';
       const readMoreLink = document.createElement('a');
       readMoreLink.className = 'ucb-campus-news-grid-link';
-      // TODO: Update this once the D10 read more page is done.
       readMoreLink.href = baseURL + readMorePath(categoryFilter, audienceFilter, unitFilter);
       readMoreLink.innerText = 'Read on CU Boulder Today';
 

--- a/js/ucb-campus-news.js
+++ b/js/ucb-campus-news.js
@@ -56,7 +56,7 @@
     // TODO: Change to production URL.
     const baseURL = 'https://live-ucbprod-today.pantheonsite.io';
     const params = new URLSearchParams({
-      'include[node--ucb_article]': 'uid,title,created,field_ucb_article_summary,field_ucb_article_thumbnail',
+      'include[node--ucb_article]': 'uid,title,created,field_ucb_article_thumbnail,field_ucb_article_summary',
       'include': 'field_ucb_article_thumbnail.field_media_image',
       'fields[file--file]': 'uri,url',
       'sort[sort-created][path]': 'created',
@@ -76,8 +76,7 @@
     return {
       articleHTML: json['data'].map(article => {
         const articleURL = baseURL + safe(article['attributes']['path']['alias']);
-        let articleThumbnailURL;
-        let articleThumbnailAlt;
+        let articleThumbnailURL, articleThumbnailAlt;
         if (renderStyle !== '3' && article['relationships']['field_ucb_article_thumbnail']['data']) {
           // Article has a thumbnail image and the Title [only] render style
           // isn't selected.
@@ -220,8 +219,6 @@
    */
   function safe(text) {
     return text
-      // Strips unsupported MathML tags.
-      .replace(/<\/?mml[^>]*>/gi, '')
       // Escapes HTML characters.
       .replace(/&/g, '&amp;')
       .replace(/</g, '&lt;')
@@ -246,7 +243,8 @@
      * Loads all articles for this Campus News block.
      */
     async loadArticles() {
-      this.renderLoader(false);
+      this.renderLoader(true);
+
       let renderStyle = this.getAttribute('rendermethod');
       const dataFilters = this.getAttribute('filters');
       const itemCount = parseInt(this.getAttribute('count')) + 3;
@@ -260,12 +258,12 @@
 
       // Fetch final URL, render in requested renderStyle
       /*
-      * 0 - Teaser
-      * 1 - Grid
-      * 2 - Title & Thumbnail
-      * 3 - Title Only
-      * 4 - Feature Block
-      */
+       * 0 - Teaser
+       * 1 - Grid
+       * 2 - Title & Thumbnail
+       * 3 - Title Only
+       * 4 - Feature Block
+       */
       let data;
       try {
         data = await jsonAPILoadArticles(categoryFilter, audienceFilter, unitFilter, renderStyle, itemCount);
@@ -315,36 +313,29 @@
      *   configuration.
      */
     render(dataArr, renderStyle, readMoreURL, itemCount) {
-      this.renderLoader(true)
-
       switch (renderStyle) {
         case '0':
           this.renderTeaser(dataArr, readMoreURL, itemCount);
           break;
-
         case '1':
           this.renderGrid(dataArr, readMoreURL, itemCount);
           break;
-
         case '2':
           this.renderTitleThumbnail(dataArr, readMoreURL, itemCount);
           break;
-
         case '3':
           this.renderTitle(dataArr, readMoreURL, itemCount);
           break;
-
         case '4':
           this.renderFeature(dataArr, readMoreURL, itemCount);
           break;
-
         case 'error':
           this.renderNoResultsError();
           break;
-
         default:
           this.renderTeaser(dataArr, readMoreURL, itemCount);
       }
+      this.renderLoader(false);
     }
 
     /**
@@ -379,8 +370,6 @@
         articleContainerText.innerHTML += article.summary;
         articleContainer.appendChild(articleContainerText);
 
-        // Hide loader
-        this.renderLoader(false);
         // Append
         this.appendChild(articleContainer);
       }
@@ -432,8 +421,6 @@
           moreLinkElement.href = absoluteURL;
         }
       }
-      // Hide loader
-      this.renderLoader(false);
       // Append grid
       this.appendChild(gridContainer);
 
@@ -469,8 +456,6 @@
         const articleContainer = document.createElement('div');
         articleContainer.classList = 'ucb-campus-news-title-only';
         articleContainer.innerHTML += article.title;
-        // Hide loader
-        this.renderLoader(false);
         // Append
         this.appendChild(articleContainer);
       }
@@ -509,8 +494,7 @@
         articleContainer.innerHTML = article.thumbnail;
         articleContainer.innerHTML += article.title;
 
-        // Hide loader and Append
-        this.renderLoader(false);
+        // Append
         this.appendChild(articleContainer);
       }
 
@@ -572,8 +556,7 @@
           const remainingFeatureContainer = document.createElement('div');
           remainingFeatureContainer.classList = 'article-feature-block-remaining col-lg-4 col-md-4 col-sm-4 col-xs-12';
           remainingFeatureContainer.id = 'remaining-feature-container';
-          // Append & Hide Loader
-          this.renderLoader(false);
+          // Append
           featureBlockContainer.appendChild(remainingFeatureContainer);
         } else {
           // Create article container
@@ -599,8 +582,6 @@
       errorMessage.classList = 'ucb-campus-news-error-message';
 
       errorMessage.innerText = 'Error retrieving results from CU Boulder Today - check filters and try again';
-      // Remove loader, render error
-      this.renderLoader(false);
       // Append
       errorContainer.appendChild(errorMessage);
       this.appendChild(errorContainer);

--- a/js/ucb-campus-news.js
+++ b/js/ucb-campus-news.js
@@ -34,7 +34,7 @@
       params.append('audience', audienceFilter.join(' '));
     }
     if (unitFilter.length > 0) {
-      params.append('unit', audienceFilter.join(' '));
+      params.append('unit', unitFilter.join(' '));
     }
 
     const paramsString = params.toString();

--- a/src/Plugin/Block/CampusNewsBlock.php
+++ b/src/Plugin/Block/CampusNewsBlock.php
@@ -256,7 +256,7 @@ class CampusNewsBlock extends StyledBlock implements ContainerFactoryPluginInter
       ],
       '#states' => [
         'visible' => [
-          'input[name="settings[filter_' . $filterName . '][enable_filter]"]' => [
+          'input[name="settings[tabs][content][filter_' . $filterName . '][enable_filter]"]' => [
             'checked' => TRUE,
           ],
         ],

--- a/src/Plugin/Block/CampusNewsBlock.php
+++ b/src/Plugin/Block/CampusNewsBlock.php
@@ -86,7 +86,7 @@ class CampusNewsBlock extends StyledBlock implements ContainerFactoryPluginInter
     $moduleFilterConfiguration = $this->moduleConfiguration->get('filters');
     foreach ($moduleFilterConfiguration as $filterMachineName => $moduleFilterConfigurationItem) {
       $blockFilterConfigurationItem = array_key_exists($filterMachineName, $blockFilterConfiguration) ? $blockFilterConfiguration[$filterMachineName] : [
-        'enabled' => 0,
+        'enabled' => FALSE,
         'includes' => [],
       ];
       $filters[$filterMachineName] = $blockFilterConfigurationItem['enabled'] ? $blockFilterConfigurationItem['includes'] : [0];
@@ -165,27 +165,9 @@ class CampusNewsBlock extends StyledBlock implements ContainerFactoryPluginInter
           });
           // Iterates over trails.
           foreach ($trails as $trail) {
-            $parentTrailSize = count($trail) - 1;
-            if ($parentTrailSize > 0) {
-              // Valid trails will have a size of more than 0.
-              $parentIncluded = FALSE;
-              for ($parentIdIndex = 0; $parentIdIndex < $parentTrailSize; $parentIdIndex++) {
-                $includeParentId = intval($trail[$parentIdIndex]);
-                // Examine if the parent if already included.
-                if ($includeParentId > 0 && in_array($includeParentId, $includesProcessed)) {
-                  $parentIncluded = TRUE;
-                  break;
-                }
-              }
-              if (!$parentIncluded) {
-                // If an item's parent is not included, add the item. An item
-                // with an included parent doesn't need to be added as it will
-                // be included in results as part of the parent.
-                $includeInt = intval($trail[$parentTrailSize]);
-                if ($includeInt > 0) {
-                  $includesProcessed[] = $includeInt;
-                }
-              }
+            $includeInt = intval($trail[count($trail) - 1]);
+            if ($includeInt > 0) {
+              $includesProcessed[] = $includeInt;
             }
           }
         }
@@ -217,7 +199,7 @@ class CampusNewsBlock extends StyledBlock implements ContainerFactoryPluginInter
       $values = $formValues['filter_' . $filterMachineName];
       $idArray = $form_state->getValue('filter_' . $filterMachineName . '_includes') ?? [];
       $this->configuration['filters'][$filterMachineName] = [
-        'enabled' => $values['enable_filter'],
+        'enabled' => !!$values['enable_filter'],
         'includes' => $idArray,
       ];
     }
@@ -239,7 +221,7 @@ class CampusNewsBlock extends StyledBlock implements ContainerFactoryPluginInter
   private function addFilterToForm(array &$form, $label, $taxonomy, $filterName) {
     $blockFilterConfiguration = $this->configuration['filters'];
     $blockFilterConfigurationItem = array_key_exists($filterName, $blockFilterConfiguration) ? $blockFilterConfiguration[$filterName] : [
-      'enabled' => 0,
+      'enabled' => FALSE,
       'includes' => [],
     ];
     $form['filter_' . $filterName] = [

--- a/src/Plugin/Block/CampusNewsBlock.php
+++ b/src/Plugin/Block/CampusNewsBlock.php
@@ -144,7 +144,12 @@ class CampusNewsBlock extends StyledBlock implements ContainerFactoryPluginInter
         $includesPreprocessed = array_keys($filterFormValues['container']['checkboxes']);
         if (count($includesPreprocessed) > $filterIncludeLimit) {
           // It's a good idea to limit the length.
-          $form_state->setErrorByName('settings][filter_' . $filterMachineName . '][container][checkboxes', 'Too many items selected to filter by ' . $moduleFilterConfigurationItem['label'] . '.');
+          $form_state->setErrorByName(
+            'settings][tabs][content][filter_' . $filterMachineName . '][container][checkboxes',
+            $this->t('Too many items selected to filter by @name.', [
+              '@name' => $moduleFilterConfigurationItem['label'],
+            ])
+          );
         }
         else {
           $trails = [];
@@ -188,7 +193,12 @@ class CampusNewsBlock extends StyledBlock implements ContainerFactoryPluginInter
           // If the filter is enabled, at least one of the boxes should be
           // checked to include any results at all (or it may just include
           // everything which doesn't make sense with the filter enabled).
-          $form_state->setErrorByName('settings][filter_' . $filterMachineName . '][container][checkboxes', 'Please select at least one item to filter by ' . $moduleFilterConfigurationItem['label'] . '.');
+          $form_state->setErrorByName(
+            'settings][tabs][content][filter_' . $filterMachineName . '][container][checkboxes',
+            $this->t('Please select at least one item to filter by @name.', [
+              '@name' => $moduleFilterConfigurationItem['label'],
+            ])
+          );
         }
       }
       $form_state->setValue('filter_' . $filterMachineName . '_includes', $includesProcessed);

--- a/src/Plugin/Block/CampusNewsBlock.php
+++ b/src/Plugin/Block/CampusNewsBlock.php
@@ -117,7 +117,7 @@ class CampusNewsBlock extends StyledBlock implements ContainerFactoryPluginInter
     $this->addConfigSelectToForm($buildArray, 'count');
     $moduleFilterConfiguration = $this->moduleConfiguration->get('filters');
     foreach ($moduleFilterConfiguration as $filterMachineName => $moduleFilterConfigurationItem) {
-      $this->addFilterToForm($buildArray, $moduleFilterConfigurationItem['label'], $moduleFilterConfigurationItem['path'], $filterMachineName);
+      $this->addFilterToForm($buildArray, $moduleFilterConfigurationItem['label'], $moduleFilterConfigurationItem['taxonomy'], $filterMachineName);
     }
     return parent::blockForm($buildArray, $form_state);
   }
@@ -221,12 +221,12 @@ class CampusNewsBlock extends StyledBlock implements ContainerFactoryPluginInter
    *   The block configuration form render array.
    * @param string $label
    *   The display label of the filter.
-   * @param string $path
-   *   The API path of the filter relative to the baseURI.
+   * @param string $taxonomy
+   *   The name of the taxonomy term this filter is associated with.
    * @param string $filterName
    *   The machine name of the filter.
    */
-  private function addFilterToForm(array &$form, $label, $path, $filterName) {
+  private function addFilterToForm(array &$form, $label, $taxonomy, $filterName) {
     $blockFilterConfiguration = $this->configuration['filters'];
     $blockFilterConfigurationItem = array_key_exists($filterName, $blockFilterConfiguration) ? $blockFilterConfiguration[$filterName] : [
       'enabled' => 0,
@@ -266,7 +266,7 @@ class CampusNewsBlock extends StyledBlock implements ContainerFactoryPluginInter
         '#theme' => 'cuboulder_today_filter_form_loader',
         '#data' => [
           'label' => $label,
-          'path' => $path,
+          'taxonomy' => $taxonomy,
           'machineName' => $filterName,
           'configuration' => $blockFilterConfigurationItem,
         ],

--- a/src/Plugin/Block/CampusNewsBlock.php
+++ b/src/Plugin/Block/CampusNewsBlock.php
@@ -235,7 +235,7 @@ class CampusNewsBlock extends StyledBlock implements ContainerFactoryPluginInter
       '#title' => 'Filter by ' . $label,
       '#attributes' => [
         'class' => ['cuboulder-today-filter-form-enable'],
-        'id' => ['cuboulder_today_filter_form_enable_' . $filterName],
+        'data-filter' => $filterName,
       ],
       '#default_value' => $blockFilterConfigurationItem['enabled'],
     ];

--- a/templates/cuboulder-today-filter-form-loader.html.twig
+++ b/templates/cuboulder-today-filter-form-loader.html.twig
@@ -1,12 +1,18 @@
 {{ attach_library('ucb_campus_news/cuboulder_today_filter_form_loader') }}
 <script type="text/javascript">
-  (function(drupal, label, taxonomy, machineName, configuration) {
+  (function(baseURL, label, taxonomy, machineName, configuration) {
     if (/complete|interactive|loaded/.test(document.readyState)) {
-      cuboulderTodayFilterFormLoader(drupal, label, taxonomy, machineName, configuration);
+      cuboulderTodayFilterFormLoader(Drupal, baseURL, label, taxonomy, machineName, configuration);
     } else {
       window.addEventListener('DOMContentLoaded', function() {
-        cuboulderTodayFilterFormLoader(drupal, label, taxonomy, machineName, configuration);
+        cuboulderTodayFilterFormLoader(Drupal, baseURL, label, taxonomy, machineName, configuration);
       });
     }
-  })(Drupal, '{{ data.label }}', '{{ data.taxonomy }}', '{{ data.machineName }}', {{ data.configuration|json_encode()|raw }})
+  })(
+    '{{ globalConfig.baseURL }}',
+    '{{ data.label }}',
+    '{{ data.taxonomy }}',
+    '{{ data.machineName }}',
+    {{ data.configuration|json_encode()|raw }}
+  );
 </script>

--- a/templates/cuboulder-today-filter-form-loader.html.twig
+++ b/templates/cuboulder-today-filter-form-loader.html.twig
@@ -1,12 +1,12 @@
 {{ attach_library('ucb_campus_news/cuboulder_today_filter_form_loader') }}
 <script type="text/javascript">
-  (function(siteURI, baseURI, label, path, machineName, configuration) {
+  (function(drupal, label, taxonomy, machineName, configuration) {
     if (/complete|interactive|loaded/.test(document.readyState)) {
-      cuboulderTodayFilterFormLoader(Drupal, siteURI, baseURI, label, path, machineName, configuration);
+      cuboulderTodayFilterFormLoader(drupal, label, taxonomy, machineName, configuration);
     } else {
       window.addEventListener('DOMContentLoaded', function() {
-        cuboulderTodayFilterFormLoader(Drupal, siteURI, baseURI, label, path, machineName, configuration);
+        cuboulderTodayFilterFormLoader(drupal, label, taxonomy, machineName, configuration);
       });
     }
-  })('{{ globalConfig.siteURI }}', '{{ globalConfig.baseURI }}', '{{ data.label }}', '{{ data.path }}', '{{ data.machineName }}', {{ data.configuration|json_encode()|raw }})
+  })(Drupal, '{{ data.label }}', '{{ data.taxonomy }}', '{{ data.machineName }}', {{ data.configuration|json_encode()|raw }})
 </script>

--- a/templates/ucb-campus-news.html.twig
+++ b/templates/ucb-campus-news.html.twig
@@ -1,6 +1,7 @@
 {{ attach_library('ucb_campus_news/ucb-campus-news') }}
 <campus-news{{
   attributes
+    .setAttribute('base-url', globalConfig.baseURL)
     .setAttribute('display', data.display)
     .setAttribute('filters', data.filters|json_encode)
     .setAttribute('count', data.count)

--- a/templates/ucb-campus-news.html.twig
+++ b/templates/ucb-campus-news.html.twig
@@ -1,9 +1,10 @@
 {{ attach_library('ucb_campus_news/ucb-campus-news') }}
 <campus-news{{
-    attributes.setAttribute('rendermethod', data.display)
-      .setAttribute('filters', data.filters|json_encode)
-      .setAttribute('count', data.count)
-  }}>
+  attributes
+    .setAttribute('display', data.display)
+    .setAttribute('filters', data.filters|json_encode)
+    .setAttribute('count', data.count)
+}}>
   {# Loading message #}
   <div class="ucb-list-msg ucb-loading-data text-center">
     <i class="fa-solid fa-spinner fa-3x fa-pulse"></i>

--- a/ucb_campus_news.info.yml
+++ b/ucb_campus_news.info.yml
@@ -1,6 +1,6 @@
 name: CU Boulder Campus News
 description: 'Provides a block for CU Boulder campus news.'
-core_version_requirement: '^10'
+core_version_requirement: '^10 || ^11'
 type: module
 version: '2.0'
 package: CU Boulder

--- a/ucb_campus_news.info.yml
+++ b/ucb_campus_news.info.yml
@@ -1,8 +1,8 @@
 name: CU Boulder Campus News
 description: 'Provides a block for CU Boulder campus news.'
-core_version_requirement: '^9.5 || ^10'
+core_version_requirement: '^10'
 type: module
-version: '1.1'
+version: '2.0'
 package: CU Boulder
 dependencies:
   - block

--- a/ucb_campus_news.install
+++ b/ucb_campus_news.install
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * @file
+ * Contains update hooks used by the CU Boulder Campus News module.
+ */
+
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Updates the configuration.
+ *
+ * @param string[] $configKeys
+ *   The configuration to update.
+ */
+function _ucb_campus_news_update_config(array $configKeys) {
+  $modulePath = Drupal::getContainer()->get('extension.path.resolver')->getPath('module', 'ucb_campus_news');
+  $configYaml = Yaml::parse(file_get_contents($modulePath . '/config/install/ucb_campus_news.configuration.yml'));
+  $configEditable = \Drupal::configFactory()->getEditable('ucb_campus_news.configuration');
+  foreach ($configKeys as $configKey) {
+    $configEditable->set($configKey, $configYaml[$configKey]);
+  }
+  $configEditable->save();
+}
+
+/**
+ * Updates configuration to work with JSON API on the migrated Today site.
+ */
+function ucb_campus_news_update_10201() {
+  _ucb_campus_news_update_config([
+    'filters',
+  ]);
+}

--- a/ucb_campus_news.install
+++ b/ucb_campus_news.install
@@ -28,6 +28,7 @@ function _ucb_campus_news_update_config(array $configKeys) {
  */
 function ucb_campus_news_update_10201() {
   _ucb_campus_news_update_config([
+    'baseURL',
     'filters',
   ]);
 }

--- a/ucb_campus_news.module
+++ b/ucb_campus_news.module
@@ -11,9 +11,7 @@
 function ucb_campus_news_theme() {
   $config = \Drupal::config('ucb_campus_news.configuration');
   $globalConfigVariables = [
-    'siteURI' => $config->get('siteURI'),
-    'baseURI' => $config->get('baseURI'),
-    'path' => $config->get('path'),
+    'baseURL' => $config->get('baseURL'),
     'display' => $config->get('display'),
     'count' => $config->get('count'),
     'filters' => $config->get('filters'),


### PR DESCRIPTION
This is a major update to the CU Boulder Campus News module. This update:

- [new] Adds support for the Drupal 10 version of CU Boulder Today by calling the JSON API. If the call to the JSON API fails, Campus News block features can still fall back to using the legacy (Drupal 7) API. Resolves CuBoulder/ucb_campus_news#12
- [bug, severity:minor] Fixes checkboxes not hiding underneath filters when "Filter by x" is unchecked. Resolves CuBoulder/ucb_campus_news#15

Technical information: This update contains an update hook.