### PR TITLE
Fixes legacy (Drupal 7) Today site API article sorting

### DIFF
--- a/js/ucb-campus-news.js
+++ b/js/ucb-campus-news.js
@@ -237,9 +237,7 @@
       };
     });
 
-    dataArr.sort((a, b) =>
-      parseFloat(b.created.getMilliseconds()) - parseFloat(a.created.getMilliseconds())
-    );
+    dataArr.sort((a, b) => b.created - a.created);
 
     return {
       articleHTML: dataArr,

--- a/ucb_campus_news.info.yml
+++ b/ucb_campus_news.info.yml
@@ -2,7 +2,7 @@ name: CU Boulder Campus News
 description: 'Provides a block for CU Boulder campus news.'
 core_version_requirement: '^10 || ^11'
 type: module
-version: '2.0'
+version: '2.0.1'
 package: CU Boulder
 dependencies:
   - block


### PR DESCRIPTION
An issue existed where articles coming from the legacy (Drupal 7) Today site API weren't getting sorted correctly. This update resolves the issue.

[bug] Resolves CuBoulder/ucb_campus_news#18